### PR TITLE
Android Studio and compile warnings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,9 +9,6 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
-        ndk {
-            abiFilters "armeabi-v7a", "x86"
-        }
     }
     lintOptions {
        warning 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,6 @@ android {
 }
 
 dependencies {
-    provided 'com.facebook.react:react-native:+'
-    provided 'com.google.android.gms:play-services-gcm:+'
+    compileOnly 'com.facebook.react:react-native:+'
+    compileOnly 'com.google.android.gms:play-services-gcm:+'
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-sim-data",
   "version": "2.0.3",
   "description": "React Native plugin to get the device's SIM data (carrier name, mcc mnc, country code, phone number, etc)",
-  "main": "index.js",
+  "main": "index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/pocesar/react-native-sim-data"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prepublishOnly": "tsc -p tsconfig.json"
   },
-  "typings": "index.d.ts",
+  "typings": "extend.d.ts",
   "keywords": [
     "react-component",
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sim-data",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "React Native plugin to get the device's SIM data (carrier name, mcc mnc, country code, phone number, etc)",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
Solution for: #6 

- - -

- [x] Replace the main file of the module (the module was not compiling)
- [x] Replace the typings of the module
- [x] Replace deprecated `provided` to `compileOnly`
- [x] Use SDK 26 as default since is required for Google Play Services
- [x] Use app sdk and build tools to avoid compile warnings
- [x] Remove `abiFilters` since React Native 0.60+ is prepared for all architectures
- [x] Update module version

- - -

Please test it with RN versions older than 0.60, just to make sure.